### PR TITLE
Return no tracker if `flair_string` is `None`

### DIFF
--- a/flair/flairparsing.py
+++ b/flair/flairparsing.py
@@ -74,6 +74,8 @@ def tracker_type(flair_string):
 
     # This covers for when the account doesn't have a tracker emoji (ie: no space or if we allow as a policy) or is a legacy flair and is matching on URL's instead
 
+    if not flair_string:
+        return "notracker"
     if "anidb.net" in flair_string:
         return "Anidb"
     if "anilist.co" in flair_string:


### PR DESCRIPTION
When I logged into the site for the first time, I got a "`None` is not iterable" error because this function assumes `flair_string` will be a string. I've added handling for the case that it's not present.