### PR TITLE
Add 2FA TOTP support if in config

### DIFF
--- a/flair/redditflair.py
+++ b/flair/redditflair.py
@@ -53,13 +53,19 @@ def reddit_setup():
     global subreddit_name
     load_dotenv()
 
+    password = os.environ.get('REDDIT_USER_PASSWORD')
+    totp_secret = os.environ.get('REDDIT_TOTP_SECRET')
+    if totp_secret:
+        import mintotp
+        password = f"{password}:{mintotp.totp(totp_secret)}"
+
     # SCRIPT FORMAT
     reddit = praw.Reddit(
         client_id=os.environ.get('REDDIT_CLIENT_ID'),
         client_secret=os.environ.get('REDDIT_SECRET'),
         username=os.environ.get('REDDIT_USERNAME'),
         user_agent=os.environ.get('REDDIT_USER_AGENT'),
-        password=os.environ.get('REDDIT_USER_PASSWORD'),
+        password=password,
         redirect_uri=os.environ.get('REDIRECT_URI'),
     )
 
@@ -70,6 +76,7 @@ def reddit_setup():
     # print('DEBUG: ' + os.environ.get('REDDIT_USERNAME'))
     # print('DEBUG: ' + os.environ.get('REDDIT_USER_AGENT'))
     # print('DEBUG: ' + os.environ.get('REDDIT_USER_PASSWORD'))
+    # print('DEBUG: ' + os.environ.get('REDDIT_TOTP_SECRET'))
 
     try:
         reddit.user.me()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ django-allauth==0.44.0
 prawcore==1.4.0
 praw==6.5.1
 python-dotenv==0.17.1
+mintotp==0.3.0

--- a/template.env
+++ b/template.env
@@ -4,6 +4,7 @@ REDDIT_SECRET=
 REDDIT_USERNAME=
 REDDIT_USER_AGENT=django:animeflairsetter:1.0 (by /u/badspler)
 REDDIT_USER_PASSWORD=
+REDDIT_TOTP_SECRET=
 
 REDIRECT_URI=http://localhost:8080
 


### PR DESCRIPTION
Using `REDDIT_TOTP_SECRET` as the environment variable for the 2FA setup key. If not set, assumes it's not enabled.

Including the import inside the if statement is intentional as it's not even necessary to have the library installed if it's not on, but that could be moved to the top like normal.